### PR TITLE
Fixed cli output sending everything to stderr

### DIFF
--- a/internal/cli/commands/root.go
+++ b/internal/cli/commands/root.go
@@ -15,6 +15,8 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/teserakt-io/automation-engine/internal/cli"
@@ -85,6 +87,9 @@ func NewRootCommand(c2aeClientFactory cli.APIClientFactory, version string) Comm
 	)
 
 	cobraCmd.SetVersionTemplate(`{{printf "%s" .Version}}`)
+
+	cobraCmd.SetOut(os.Stdout)
+	cobraCmd.SetErr(os.Stderr)
 
 	rootCmd.cobraCmd = cobraCmd
 


### PR DESCRIPTION
CLI was redirecting all output to stderr. Now it split it properly between stdout and stderr depending on the message (normal output vs usage / error)